### PR TITLE
Move guides to their own subindex

### DIFF
--- a/source/guides/index.rst
+++ b/source/guides/index.rst
@@ -5,3 +5,4 @@ Guides
    :maxdepth: 1
 
    getting-started
+   realtime-alerts

--- a/source/toc-main.rst
+++ b/source/toc-main.rst
@@ -2,8 +2,7 @@
    :titlesonly:
    :hidden:
 
-   /guides/getting-started
-   /guides/realtime-alerts
+   /guides/index
    /concepts/index
    /reference/index
    /sdk/index


### PR DESCRIPTION
I think this looks less cluttered

![screen shot 2015-02-02 at 5 58 44 pm](https://cloud.githubusercontent.com/assets/2736406/6011758/2d689d5e-ab05-11e4-8ef2-0bedefc1e1aa.png)
