### PR TITLE
Redirects

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -34,7 +34,8 @@ if not tags.has('dev'):
 extensions = [
     'sphinx.ext.todo',
     'tempoiq_sphinx',
-    'snippets'
+    'snippets',
+    'redirect'
 ]
 
 

--- a/source/redirects
+++ b/source/redirects
@@ -1,1 +1,11 @@
+concepts/index.rst ../index.rst
+concepts/data-model.rst ../organize.rst
+concepts/pipeline.rst ../build.rst
+concepts/reading.rst ../build.rst
+concepts/writing.rst ../collect.rst
+guides/index.rst ../index.rst
 guides/getting-started.rst ../index.rst
+reference/methods/device-sensor-crud.rst ../../organize.rst
+reference/methods/index.rst ../../index.rst
+reference/methods/read.rst ../../build.rst
+reference/methods/write.rst ../../collect.rst

--- a/source/redirects
+++ b/source/redirects
@@ -1,0 +1,1 @@
+guides/getting-started.rst ../index.rst

--- a/source/sphinxext/redirect.py
+++ b/source/sphinxext/redirect.py
@@ -1,0 +1,57 @@
+# A simple sphinx plugin which creates HTML redirections from old names
+# to new names. It does this by looking for files named "redirect" in
+# the documentation source and using the contents to create simple HTML
+# redirection pages for changed filenames.
+#
+# Redirect file should contain one redirect per line, where each line
+# is the from and to path separated by a space. Both paths should be
+# relative to the directory that the redirect file is in.
+#
+# From:
+# https://github.com/openstack/nova-specs/blob/master/doc/source/redirect.py
+
+import os.path
+
+from sphinx.application import ENV_PICKLE_FILENAME
+from sphinx.util.console import bold
+
+
+def setup(app):
+    from sphinx.application import Sphinx
+    if not isinstance(app, Sphinx):
+        return
+    app.connect('build-finished', emit_redirects)
+
+
+def process_redirect_file(app, path, ent):
+    parent_path = path.replace(app.builder.srcdir, app.builder.outdir)
+    with open(os.path.join(path, ent)) as redirects:
+        for line in redirects.readlines():
+            from_path, to_path = line.rstrip().split(' ')
+            from_path = from_path.replace('.rst', '.html')
+            to_path = to_path.replace('.rst', '.html')
+
+            redirected_filename = os.path.join(parent_path, from_path)
+            redirected_directory = os.path.dirname(redirected_filename)
+            if not os.path.exists(redirected_directory):
+                os.makedirs(redirected_directory)
+            with open(redirected_filename, 'w') as f:
+                f.write('<html><head><meta http-equiv="refresh" content="0; '
+                        'url=%s" /></head></html>'
+                        % to_path)
+
+
+def emit_redirects(app, exc):
+    app.builder.info(bold('scanning %s for redirects...') % app.builder.srcdir)
+
+    def process_directory(path):
+        for ent in os.listdir(path):
+            p = os.path.join(path, ent)
+            if os.path.isdir(p):
+                process_directory(p)
+            elif ent == 'redirects':
+                app.builder.info('   found redirects at %s' % p)
+                process_redirect_file(app, path, ent)
+
+    process_directory(app.builder.srcdir)
+    app.builder.info('...done')

--- a/source/sphinxext/redirect.py
+++ b/source/sphinxext/redirect.py
@@ -4,8 +4,8 @@
 # redirection pages for changed filenames.
 #
 # Redirect file should contain one redirect per line, where each line
-# is the from and to path separated by a space. Both paths should be
-# relative to the directory that the redirect file is in.
+# has the from and to paths separated by a space. The from path is relative
+# to the redirect file, and the to path is relative to the from file.
 #
 # From:
 # https://github.com/openstack/nova-specs/blob/master/doc/source/redirect.py


### PR DESCRIPTION
Add an extension that generates HTML meta redirect pages based on a mapping file. Added redirects for most of the pages that got moved in the reorg last week. Didn't bother doing each individual domain object page since I don't expect they're linked much directly, but I can add those if we think it's important.